### PR TITLE
Add more specific string literal matching

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -6,13 +6,14 @@ import argparse
 # Define patterns for detecting non-FIPS compliant algorithms, weak key lengths, and RNGs.
 non_fips_patterns = {
     'algorithms': {
-        'MD2': r'MD2',
-        'MD5': r'MD5',
-        'SHA1': r'SHA1',
-        'DES': r'DES',
-        'RC4': r'RC4',
+        'MD2': r'[\'"]MD2',
+        'MD5': r'[\'"]MD5',
+        'SHA1': r'[\'"]SHA1',
+        'DES': r'[\'"]DES[\'"/]',
+        '3DES': r'[\'"]DESede',
+        'RC4': r'[\'"]RC4',
     },
-    'key_lengths': [(r'AES', 128)],
+    'key_lengths': [(r'[\'"]AES[\'"/]', 128)],
     'rngs': [r'java\.util\.Random'],
 }
 


### PR DESCRIPTION
Some of the patterns are picking up code comments, and unrelated
english words - for example javadoc comment for DESCRIPTION of an sql
schema.

Ensure that relevant digests literal strings are looked up as part of
a string, ie. "MD5" 'MD5' 'MD5WithRsa' and so on. This somewhat
reduces false positive matches, but possibly increases false
negatives.

Possibly need to add a range of patterns, i.e. apache commons can
access digest by string, but also with a specific method name or
constant. Such that maybe matching should be added for getSha1Digest()
ahd SHA_1, however not sure how useful that is as all of apache
commons codecs is not a certified implementation.
